### PR TITLE
Fix incorrect dtype of cv2.line argument

### DIFF
--- a/misc/objdet_tools.py
+++ b/misc/objdet_tools.py
@@ -232,7 +232,7 @@ def project_detections_into_bev(bev_map, detections, configs, color=[]):
         cv2.polylines(bev_map, [corners_int], True, color, 2)
 
         # draw colored line to identify object front
-        corners_int = bev_corners.reshape(-1, 2)
+        corners_int = bev_corners.reshape(-1, 2).astype(int)
         cv2.line(bev_map, (corners_int[0, 0], corners_int[0, 1]), (corners_int[3, 0], corners_int[3, 1]), (255, 255, 0), 2)
 
 


### PR DESCRIPTION
Fix the following error:
Traceback (most recent call last):
  File "/home/loop_over_dataset.py", line 208, in <module>
    tools.show_objects_in_bev_labels_in_camera(detections, lidar_bev, image, frame.laser_labels, valid_label_flags, camera_calibration, configs_det)
  File "/home/misc/objdet_tools.py", line 387, in show_objects_in_bev_labels_in_camera                                                                              project_detections_into_bev(bev_map, detections, configs)                     File "/home/misc/objdet_tools.py", line 237, in project_detections_into_bev
    cv2.line(bev_map, (corners_int[0, 0], corners_int[0, 1]), (corners_int[3, 0], corners_int[3, 1]), (255, 255, 0), 2)
cv2.error: OpenCV(4.6.0) 👎 error: (-5:Bad argument) in function 'line'
> Overload resolution failed:                                                   >  - Can't parse 'pt1'. Sequence item with index 0 has a wrong type
>  - Can't parse 'pt1'. Sequence item with index 0 has a wrong type